### PR TITLE
Add required category field in fifxtures

### DIFF
--- a/src/Elcodi/Fixtures/DataFixtures/ORM/Category/CategoryData.php
+++ b/src/Elcodi/Fixtures/DataFixtures/ORM/Category/CategoryData.php
@@ -59,6 +59,7 @@ class CategoryData extends AbstractFixture
             ->setMetaKeywords('Women Shirts')
             ->setEnabled(true)
             ->setRoot(true)
+            ->setShowInHome(true)
             ->setPosition(0);
 
         $categoryObjectManager->persist($womenCategory);
@@ -110,6 +111,7 @@ class CategoryData extends AbstractFixture
             ->setMetaKeywords('Men Shirts')
             ->setEnabled(true)
             ->setRoot(true)
+            ->setShowInHome(true)
             ->setPosition(1);
 
         $categoryObjectManager->persist($menCategory);


### PR DESCRIPTION
The field `show_in_home` cannot be null so the fixtures install fails. Another solution could be to set the default value as `true` or `false` in the entity itself.